### PR TITLE
Canonical urls

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -128,5 +128,12 @@ module.exports = {
         pathToConfigModule: 'src/utils/typography',
       },
     },
+    {
+      resolve: `gatsby-plugin-canonical-urls`,
+      options: {
+        siteUrl: `https://pietrorea.com`,
+        stripQueryString: true,
+      }
+    }
   ],
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "gatsby": "^2.20.0",
     "gatsby-image": "^2.0.22",
+    "gatsby-plugin-canonical-urls": "^2.2.1",
     "gatsby-plugin-feed": "^2.4.1",
     "gatsby-plugin-google-analytics": "^2.2.0",
     "gatsby-plugin-manifest": "^2.3.2",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "url": "https://github.com/gatsbyjs/gatsby-starter-blog/issues"
   },
   "dependencies": {
+    "@babel/core": "^7.9.0",
+    "@types/react": "^16.9.25",
     "gatsby": "^2.20.0",
     "gatsby-image": "^2.0.22",
     "gatsby-plugin-canonical-urls": "^2.2.1",
@@ -32,6 +34,7 @@
     "react-typography": "^0.16.13",
     "typeface-merriweather": "0.0.43",
     "typeface-montserrat": "0.0.43",
+    "typescript": "^3.8.3",
     "typography": "^0.16.17",
     "typography-theme-wordpress-2016": "^0.15.10"
   },


### PR DESCRIPTION
- Adding the `gatsby-plugin-canonical-urls` plugin. Canonical URLS will being the format of `https://pietrorea.com/...`
- Adding some missing peer dependencies