### PR TITLE
Bupming gatsby-plugin-offline

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "gatsby-plugin-feed": "^2.4.1",
     "gatsby-plugin-google-analytics": "^2.2.0",
     "gatsby-plugin-manifest": "^2.3.2",
-    "gatsby-plugin-offline": "^2.0.5",
+    "gatsby-plugin-offline": "^3.1.1",
     "gatsby-plugin-react-helmet": "^3.0.0",
     "gatsby-plugin-sharp": "^2.0.6",
     "gatsby-plugin-typography": "^2.2.0",


### PR DESCRIPTION
- My blog is a blank page when accessed with JS turned off.
- According to this blog post, it should now serve content even if JS is turned off! https://www.gatsbyjs.org/blog/2019-11-05-how-gatsby-can-power-your-site-offline-even-without-javascript/